### PR TITLE
Automatically get recipientId when creating a Notification

### DIFF
--- a/notification-service/microservice/Notification.js
+++ b/notification-service/microservice/Notification.js
@@ -1,6 +1,6 @@
 import { sendMessageToQueue } from "../services/SQS.js"
 
-export const NotificationService = (req, res) => {
+export const notificationService = (req, res) => {
   try {
     const msg = {
       notiType: req.body.notiType,

--- a/notification-service/routes/Notification.js
+++ b/notification-service/routes/Notification.js
@@ -1,10 +1,10 @@
 import express from "express";
 import { sendMessageToQueue } from "../services/SQS.js";
-import { NotificationService } from "../microservice/Notification.js";
+import { notificationService } from "../microservice/Notification.js";
 
 const NotiRouter = express.Router();
 
-NotiRouter.post("/notiServcice", NotificationService)
+NotiRouter.post("/notiServcice", notificationService)
 
 /************************************************************
  *********************** FOR TEST ***************************

--- a/server/src/routes/User.js
+++ b/server/src/routes/User.js
@@ -10,6 +10,9 @@ import { checkUserId, updateResumeText } from "../middleware/User.js";
 import { verifyToken } from "../middleware/Auth.js";
 
 import { loadResumeToS3 } from "../middleware/fileHandle.js";
+// TEST
+// import { Notification } from "../utils/notification.js";
+// import { sendNoti } from "../services/Notification/notification.js";
 
 const UserRouter = express.Router();
 const upload = multer({ storage: multer.memoryStorage() });
@@ -27,5 +30,26 @@ UserRouter.post(
 );
 
 UserRouter.put("/addEducation", checkUserId, verifyToken, addEducation);
+
+// TEST
+// UserRouter.post("/test", async (req, res) => {
+//   try {
+//     // make Notification 
+//     const noti = Notification.requestRemindAction("requestRemindAction", "requestId_whatever_bo gi vao cx dc :D");
+//     console.log(noti);
+
+//     // send Notification data to the notification microservice
+//     await sendNoti(noti);
+    
+//     res.status(201).json({
+//       message: "success",
+//     });
+//   } catch (error) {
+//     res.status(400).json({
+//       message: "Error",
+//       error: error.message,
+//     });
+//   }
+// })
 
 export default UserRouter;

--- a/server/src/routes/User.js
+++ b/server/src/routes/User.js
@@ -34,13 +34,16 @@ UserRouter.put("/addEducation", checkUserId, verifyToken, addEducation);
 // TEST
 // UserRouter.post("/test", async (req, res) => {
 //   try {
-//     // make Notification 
-//     const noti = Notification.requestRemindAction("requestRemindAction", "requestId_whatever_bo gi vao cx dc :D");
+//     // make Notification
+//     const noti = await Notification.openingRemindAcion(
+//       "openingRemindAcion",
+//       "666e989c9dd52b874141de11",
+//     );
 //     console.log(noti);
 
 //     // send Notification data to the notification microservice
 //     await sendNoti(noti);
-    
+
 //     res.status(201).json({
 //       message: "success",
 //     });
@@ -50,6 +53,6 @@ UserRouter.put("/addEducation", checkUserId, verifyToken, addEducation);
 //       error: error.message,
 //     });
 //   }
-// })
+// });
 
 export default UserRouter;

--- a/server/src/routes/User.js
+++ b/server/src/routes/User.js
@@ -35,8 +35,8 @@ UserRouter.put("/addEducation", checkUserId, verifyToken, addEducation);
 // UserRouter.post("/test", async (req, res) => {
 //   try {
 //     // make Notification
-//     const noti = await Notification.openingRemindAcion(
-//       "openingRemindAcion",
+//     const noti = await Notification.openingRemindAction(
+//       "openingRemindAction",
 //       "666e989c9dd52b874141de11",
 //     );
 //     console.log(noti);

--- a/server/src/utils/notification.js
+++ b/server/src/utils/notification.js
@@ -40,7 +40,7 @@ export class Notification {
     return new Notification(notiType, recipientId, requestId, "", "");
   }
 
-  static async openingRemindAcion(notiType, openingId) {
+  static async openingRemindAction(notiType, openingId) {
     // fetch data to get recipientId
     const opening = await Opening.findOne({ _id: openingId });
     const recipientId = opening.referrer_id.valueOf();

--- a/server/src/utils/notification.js
+++ b/server/src/utils/notification.js
@@ -1,3 +1,6 @@
+import Request from "../models/Request.js";
+import Opening from "../models/Opening.js";
+
 /**
  * class Notification
  *
@@ -20,18 +23,28 @@ export class Notification {
     return new Notification(notiType, recipientId, "", "", "");
   }
 
-  static refererRequestMoreInfo(notiType, requestId) {
+  static async refererRequestMoreInfo(notiType, requestId) {
     // fetch data to get recipientId
-    return new Notification(notiType, "", requestId, "", "");
+    const request = await Request.findOne({ _id: requestId });
+    const recipientId = request.candidate_id.valueOf();
+    console.log(request.candidate_id.valueOf());
+
+    return new Notification(notiType, recipientId, requestId, "", "");
   }
 
-  static requestRemindAction(notiType, requestId) {
+  static async requestRemindAction(notiType, requestId) {
     // fetch data to get recipientId
-    return new Notification(notiType, "", requestId, "", "");
+    const request = await Request.findOne({ _id: requestId });
+    const recipientId = request.candidate_id.valueOf();
+
+    return new Notification(notiType, recipientId, requestId, "", "");
   }
 
-  static openingRemindAcion(notiType, openingId) {
+  static async openingRemindAcion(notiType, openingId) {
     // fetch data to get recipientId
-    return new Notification(notiType, "", "", openingId, "");
+    const opening = await Opening.findOne({ _id: openingId });
+    const recipientId = opening.referrer_id.valueOf();
+
+    return new Notification(notiType, recipientId, "", openingId, "");
   }
 }


### PR DESCRIPTION
### Overall:
This PR fetches data to make sure all Notification have recipientId

### File Changes:
- server/src/utils/notification.js: fetch data to get recipientId in the Notification constructor

### Test:
the test only provides notiType and openingId when calling Notification.openingRemindAction() but the Notification printed in Terminal includes recipientId.

<img width="1015" alt="Screenshot 2024-06-17 at 5 04 38 PM" src="https://github.com/hoangr1010/Cupid/assets/137933787/55d3a115-b0ec-4c99-afeb-7975e4a92243">
